### PR TITLE
Ensure globally registered drawers are priotised above internal drawers

### DIFF
--- a/ConfigurationManager/SettingFieldDrawer.cs
+++ b/ConfigurationManager/SettingFieldDrawer.cs
@@ -50,6 +50,8 @@ namespace ConfigurationManager
         {
             if (setting.CustomDrawer != null)
                 setting.CustomDrawer(setting is ConfigSettingEntry newSetting ? newSetting.Entry : null);
+            else if (SettingDrawHandlers.TryGetValue(setting.SettingType, out var drawMethod))
+                drawMethod(setting); // workaround to ensure that global drawers registered by plugins are prioritised above internal drawers
             else if (setting.ShowRangeAsPercent != null && setting.AcceptableValueRange.Key != null)
                 DrawRangeField(setting);
             else if (setting.AcceptableValues != null)


### PR DESCRIPTION
At present, if a plugin registers a global drawer, if the setting type is an `Enum` or has the `ShowRangeAsPercent` or `AcceptableValues` flags set, the global drawer will be ignored.

This PR addresses this by testing the registered draw handlers immediately after testing the setting's own custom drawer (which should still take priority over global registered drawers).