### PR TITLE
Add a KeyCode drawer based on the KeyboardShortcut drawer

### DIFF
--- a/ConfigurationManager/Tobey.BepInEx.ConfigurationManager.Subnautica.csproj
+++ b/ConfigurationManager/Tobey.BepInEx.ConfigurationManager.Subnautica.csproj
@@ -38,8 +38,36 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="0Harmony, Version=2.7.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HarmonyX.2.7.0\lib\net45\0Harmony.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="BepInEx, Version=5.4.20.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\BepInEx.BaseLib.5.4.20\lib\net35\BepInEx.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="MonoMod.RuntimeDetour, Version=21.12.13.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MonoMod.RuntimeDetour.21.12.13.1\lib\net452\MonoMod.RuntimeDetour.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="MonoMod.Utils, Version=21.12.13.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MonoMod.Utils.21.12.13.1\lib\net452\MonoMod.Utils.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -80,4 +108,11 @@ IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(Target
 IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(TargetPath) HS
 IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(TargetPath) AI</PostBuildEvent>
   </PropertyGroup>
+  <Import Project="..\packages\BepInEx.Core.5.4.20\build\BepInEx.Core.targets" Condition="Exists('..\packages\BepInEx.Core.5.4.20\build\BepInEx.Core.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\BepInEx.Core.5.4.20\build\BepInEx.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\BepInEx.Core.5.4.20\build\BepInEx.Core.targets'))" />
+  </Target>
 </Project>

--- a/ConfigurationManager/packages.config
+++ b/ConfigurationManager/packages.config
@@ -1,7 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="BepInEx.Analyzers" version="1.0.8" targetFramework="net35" developmentDependency="true" />
-  <package id="BepInEx.BaseLib" version="5.4.20" targetFramework="net35" developmentDependency="true" />
+  <package id="BepInEx.BaseLib" version="5.4.20" targetFramework="net472" />
+  <package id="BepInEx.Core" version="5.4.20" targetFramework="net472" />
+  <package id="HarmonyX" version="2.7.0" targetFramework="net472" />
+  <package id="Mono.Cecil" version="0.11.4" targetFramework="net472" />
+  <package id="MonoMod.RuntimeDetour" version="21.12.13.1" targetFramework="net472" />
+  <package id="MonoMod.Utils" version="21.12.13.1" targetFramework="net472" />
   <package id="Unity.InputSystem" version="1.5.0" targetFramework="net35" />
   <package id="UnityEngine" version="5.6.1" targetFramework="net35" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
At present, if a plugin wants to use a `KeyCode` rather than a `KeyboardShortcut` for handling hotkeys for whatever reason, they are forced to endure the ugly Enum ComboBox drawer.

This PR improves this by registering a global drawer for `KeyCode` based on the same logic as `KeyboardShortcut`'s drawer.